### PR TITLE
Add advertising spend by channel chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@ Perubahan:
 3) Share Google Sheet ke service account (Editor)
 4) Header sheet baris 1: `date,channel,marketplace,qty,penjualan,modal,biayaIklan,potonganMarketplace,biayaOperasional,gajiKaryawan,pajak,diskon,codFee,biayaPengiriman,biayaLainnya`
 
+### Warehouse Sheet
+- (Opsional) `GOOGLE_SHEETS_WAREHOUSE_SPREADSHEET_ID` bila menggunakan spreadsheet berbeda, default-nya memakai `GOOGLE_SHEETS_SPREADSHEET_ID`.
+- Siapkan tab/range berikut atau override dengan ENV masing-masing:
+  - `GOOGLE_SHEETS_WAREHOUSE_QUICK_STATS_RANGE` → default `WarehouseQuickStats!A1:D100`
+  - `GOOGLE_SHEETS_WAREHOUSE_STOCK_ALERTS_RANGE` → default `WarehouseStockAlerts!A1:F1000`
+  - `GOOGLE_SHEETS_WAREHOUSE_INBOUND_OUTBOUND_RANGE` → default `WarehouseMovements!A1:F1000`
+  - `GOOGLE_SHEETS_WAREHOUSE_LOCATION_MAP_RANGE` → default `WarehouseLocations!A1:D500`
+  - `GOOGLE_SHEETS_WAREHOUSE_NOTIFICATIONS_RANGE` → default `WarehouseNotifications!A1:C500`
+  - `GOOGLE_SHEETS_WAREHOUSE_USERS_RANGE` → default `WarehouseUsers!A1:D500`
+  - `GOOGLE_SHEETS_WAREHOUSE_REPORTS_RANGE` → default `WarehouseReports!A1:C500`
+  - `GOOGLE_SHEETS_WAREHOUSE_OPNAME_PLANS_RANGE` → default `WarehouseOpname!A1:D500`
+- Setiap tab menggunakan baris pertama sebagai header (misal: `title,value,trend,tone` untuk Quick Stats).
+
 ## Deploy Vercel
 Tambahkan ENV, deploy, uji `/api/sales` & `/login`.
 

--- a/pages/api/warehouse.js
+++ b/pages/api/warehouse.js
@@ -1,0 +1,178 @@
+import { getSheetsClient, valuesToObjects } from "../../lib/sheets";
+
+const DEFAULT_RANGES = {
+  quickStats: "WarehouseQuickStats!A1:D100",
+  stockAlerts: "WarehouseStockAlerts!A1:F1000",
+  inboundOutbound: "WarehouseMovements!A1:F1000",
+  locationMap: "WarehouseLocations!A1:D500",
+  notifications: "WarehouseNotifications!A1:C500",
+  users: "WarehouseUsers!A1:D500",
+  reports: "WarehouseReports!A1:C500",
+  opnamePlans: "WarehouseOpname!A1:D500",
+};
+
+function parseNumber(value) {
+  if (value === null || value === undefined || value === "") return 0;
+  const cleaned = String(value).replace(/[^0-9.,-]/g, "").replace(/,(\d{2})$/, ".$1");
+  const numeric = parseFloat(cleaned);
+  return Number.isNaN(numeric) ? 0 : numeric;
+}
+
+function envKeyFromSection(section) {
+  return `GOOGLE_SHEETS_WAREHOUSE_${section
+    .replace(/([A-Z])/g, "_$1")
+    .toUpperCase()}_RANGE`;
+}
+
+function getRangeForSection(section) {
+  const envKey = envKeyFromSection(section);
+  return process.env[envKey] || DEFAULT_RANGES[section];
+}
+
+function normaliseTone(value, fallback) {
+  const tone = (value || "").toString().trim().toLowerCase();
+  if (!tone) return fallback;
+  return tone;
+}
+
+export default async function handler(req, res) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", ["GET"]);
+    return res.status(405).json({ error: "Method Not Allowed" });
+  }
+
+  try {
+    const spreadsheetId =
+      process.env.GOOGLE_SHEETS_WAREHOUSE_SPREADSHEET_ID ||
+      process.env.GOOGLE_SHEETS_SPREADSHEET_ID;
+
+    if (!spreadsheetId) {
+      return res.status(500).json({ error: "Missing Google Sheets spreadsheet id" });
+    }
+
+    const sections = Object.keys(DEFAULT_RANGES);
+    const ranges = sections.map((section) => getRangeForSection(section));
+
+    const sheets = getSheetsClient();
+    const { data } = await sheets.spreadsheets.values.batchGet({
+      spreadsheetId,
+      ranges,
+    });
+
+    const valueRanges = data.valueRanges || [];
+    const result = {};
+
+    sections.forEach((section, index) => {
+      const values = valueRanges[index]?.values || [];
+      result[section] = valuesToObjects(values);
+    });
+
+    const quickStats = (result.quickStats || [])
+      .filter((item) => item.title || item.value)
+      .map((item) => ({
+        title: item.title || "",
+        value: item.value || "",
+        trend: item.trend || "",
+        tone: normaliseTone(item.tone, "neutral"),
+      }));
+
+    const stockAlerts = (result.stockAlerts || [])
+      .filter((item) => item.sku || item.name)
+      .map((item) => {
+        const stockRaw = item.stock;
+        const hasStock =
+          stockRaw !== undefined && stockRaw !== null && String(stockRaw).trim() !== "";
+
+        return {
+          sku: item.sku || "",
+          name: item.name || "",
+          stock: hasStock ? parseNumber(stockRaw) : null,
+          status: item.status || "",
+          location: item.location || "",
+          priority: normaliseTone(item.priority, "medium"),
+        };
+      });
+
+    const inboundOutbound = (result.inboundOutbound || [])
+      .filter((item) => item.reference || item.type)
+      .map((item) => {
+        const qtyRaw = item.qty;
+        const hasQty = qtyRaw !== undefined && qtyRaw !== null && String(qtyRaw).trim() !== "";
+
+        return {
+          type: (item.type || "").trim() || "Inbound",
+          reference: item.reference || "",
+          time: item.time || "",
+          by: item.by || "",
+          notes: item.notes || "",
+          qty: hasQty ? parseNumber(qtyRaw) : null,
+        };
+      });
+
+    const locationMap = (result.locationMap || [])
+      .filter((item) => item.zone || item.racks)
+      .map((item) => {
+        const filledRaw = item.filled;
+        const capacityRaw = item.capacity;
+        const hasFilled =
+          filledRaw !== undefined && filledRaw !== null && String(filledRaw).trim() !== "";
+        const hasCapacity =
+          capacityRaw !== undefined && capacityRaw !== null && String(capacityRaw).trim() !== "";
+
+        return {
+          zone: item.zone || "",
+          racks: item.racks || "",
+          filled: hasFilled ? parseNumber(filledRaw) : null,
+          capacity: hasCapacity ? parseNumber(capacityRaw) : null,
+        };
+      });
+
+    const notifications = (result.notifications || [])
+      .filter((item) => item.message || item.time)
+      .map((item) => ({
+        time: item.time || "",
+        message: item.message || "",
+        tone: normaliseTone(item.tone, "info"),
+      }));
+
+    const users = (result.users || [])
+      .filter((item) => item.name || item.role)
+      .map((item) => ({
+        name: item.name || "",
+        role: item.role || "",
+        status: item.status || "",
+        shift: item.shift || "",
+      }));
+
+    const reports = (result.reports || [])
+      .filter((item) => item.title || item.period)
+      .map((item) => ({
+        title: item.title || "",
+        period: item.period || "",
+        status: item.status || "",
+      }));
+
+    const opnamePlans = (result.opnamePlans || [])
+      .filter((item) => item.area || item.schedule)
+      .map((item) => ({
+        area: item.area || "",
+        schedule: item.schedule || "",
+        supervisor: item.supervisor || "",
+        status: item.status || "",
+      }));
+
+    return res.status(200).json({
+      quickStats,
+      stockAlerts,
+      inboundOutbound,
+      locationMap,
+      notifications,
+      users,
+      reports,
+      opnamePlans,
+    });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ error: error.message });
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -72,6 +72,7 @@ export default function IndexPage() {
   const [adminKey, setAdminKey] = useState('');
   const [isAdmin, setIsAdmin] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [now, setNow] = useState(() => new Date());
 
   // THEME (light/dark)
   const [theme, setTheme] = useState('light');
@@ -87,6 +88,31 @@ export default function IndexPage() {
     localStorage.setItem('AKAY_THEME', next);
     document.documentElement.classList.toggle('dark', next === 'dark');
   };
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const formattedDate = useMemo(() => {
+    const text = new Intl.DateTimeFormat('id-ID', {
+      weekday: 'long',
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    }).format(now);
+    return text.charAt(0).toUpperCase() + text.slice(1);
+  }, [now]);
+
+  const formattedTime = useMemo(
+    () =>
+      new Intl.DateTimeFormat('id-ID', {
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      }).format(now),
+    [now]
+  );
 
   // Logout (hapus cookie sesi)
   const doLogout = async () => {
@@ -266,24 +292,34 @@ export default function IndexPage() {
           {/* Responsive header layout */}
           <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
             {/* Brand */}
-            <div className="flex items-center justify-between gap-3">
-              <div className="flex items-center gap-3">
-                <img src="/akay-logo.svg" alt="AKAY" className="w-9 h-9 rounded" />
-                <div>
-                  <h1 className="text-xl font-semibold leading-tight">AKAY Sales Dashboard</h1>
-                  <p className="text-xs text-neutral-500 dark:text-neutral-400">Google Sheets ↔ Next.js • Admin/Viewer • Export</p>
+            <div className="flex flex-col gap-3">
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-3">
+                  <img src="/akay-logo.svg" alt="AKAY" className="w-9 h-9 rounded" />
+                  <div>
+                    <h1 className="text-xl font-semibold leading-tight">AKAY Sales Dashboard</h1>
+                    <p className="text-xs text-neutral-500 dark:text-neutral-400">Google Sheets ↔ Next.js • Admin/Viewer • Export</p>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setMobileMenuOpen((prev) => !prev)}
+                  className="md:hidden inline-flex items-center gap-2 px-3 py-2 rounded-full border border-neutral-300 text-sm font-medium text-neutral-700 hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-100 dark:bg-neutral-900"
+                  aria-expanded={mobileMenuOpen}
+                  aria-controls="dashboard-controls"
+                >
+                  <span className="text-lg" aria-hidden="true">☰</span>
+                  Menu
+                </button>
+              </div>
+              <div className="flex flex-col gap-1 rounded-2xl bg-white/40 px-3 py-2 shadow-sm ring-1 ring-neutral-200 md:flex-row md:items-center md:gap-3 dark:bg-neutral-900/50 dark:ring-neutral-800">
+                <div className="text-base font-semibold text-neutral-800 dark:text-neutral-100">Helo Admin</div>
+                <div className="flex flex-col gap-1 text-sm text-neutral-500 capitalize md:flex-row md:items-center md:gap-3 dark:text-neutral-400">
+                  <span>{formattedDate}</span>
+                  <span className="hidden h-3 w-px bg-neutral-300 md:inline-block dark:bg-neutral-700" aria-hidden="true"></span>
+                  <span className="font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">{formattedTime}</span>
                 </div>
               </div>
-              <button
-                type="button"
-                onClick={() => setMobileMenuOpen((prev) => !prev)}
-                className="md:hidden inline-flex items-center gap-2 px-3 py-2 rounded-full border border-neutral-300 text-sm font-medium text-neutral-700 hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-100 dark:bg-neutral-900"
-                aria-expanded={mobileMenuOpen}
-                aria-controls="dashboard-controls"
-              >
-                <span className="text-lg" aria-hidden="true">☰</span>
-                Menu
-              </button>
             </div>
             {/* Control groups */}
             <div
@@ -293,12 +329,12 @@ export default function IndexPage() {
               {/* Date group */}
               <div className="flex flex-col sm:flex-row sm:items-center gap-2">
                 <div className="flex items-center gap-2">
-                  <label className="text-sm text-neutral-600 dark:text-neutral-300">Dari</label>
-                  <input type="date" value={dateFrom} onChange={(e)=>setDateFrom(e.target.value)} className="w-full sm:w-auto px-2 py-1 rounded border border-neutral-300 text-sm dark:bg-neutral-800 dark:border-neutral-700" />
+                  <label className="text-xs sm:text-sm text-neutral-600 dark:text-neutral-300">Dari</label>
+                  <input type="date" value={dateFrom} onChange={(e)=>setDateFrom(e.target.value)} className="w-32 sm:w-auto px-2 py-1 rounded border border-neutral-300 text-xs sm:text-sm dark:bg-neutral-800 dark:border-neutral-700" />
                 </div>
                 <div className="flex items-center gap-2">
-                  <label className="text-sm text-neutral-600 dark:text-neutral-300">Sampai</label>
-                  <input type="date" value={dateTo} onChange={(e)=>setDateTo(e.target.value)} className="w-full sm:w-auto px-2 py-1 rounded border border-neutral-300 text-sm dark:bg-neutral-800 dark:border-neutral-700" />
+                  <label className="text-xs sm:text-sm text-neutral-600 dark:text-neutral-300">Sampai</label>
+                  <input type="date" value={dateTo} onChange={(e)=>setDateTo(e.target.value)} className="w-32 sm:w-auto px-2 py-1 rounded border border-neutral-300 text-xs sm:text-sm dark:bg-neutral-800 dark:border-neutral-700" />
                 </div>
               </div>
               {/* Action group */}

--- a/pages/index.js
+++ b/pages/index.js
@@ -209,6 +209,7 @@ export default function IndexPage() {
       cost: isDark ? '#f87171' : '#ef4444',
       marketing: isDark ? '#c084fc' : '#8b5cf6',
       bar: isDark ? '#f59e0b' : '#f97316',
+      profit: isDark ? '#4ade80' : '#22c55e',
       grid: isDark ? '#27272a' : '#e5e7eb',
     }),
     [isDark]
@@ -315,25 +316,43 @@ export default function IndexPage() {
       </div>
 
       {/* Filters */}
-      <div className="max-w-7xl mx-auto px-4 py-4">
+      <div className="max-w-7xl mx-auto px-4 py-3">
         <div className="grid md:grid-cols-2 gap-3">
-          <div className="rounded-2xl border border-neutral-200 bg-white p-3 dark:bg-neutral-900 dark:border-neutral-800">
-            <div className="text-sm font-medium mb-2 text-neutral-700 dark:text-neutral-200">Filter Channel</div>
-            <div className="flex flex-wrap gap-2">
+          <div className="rounded-2xl border border-neutral-200 bg-white p-3 sm:p-4 dark:bg-neutral-900 dark:border-neutral-800">
+            <div className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400 mb-2">
+              Channel
+            </div>
+            <div className="flex flex-wrap gap-1.5">
               {allChannels.map((c) => (
-                <button key={c} onClick={() => toggleSet(setChannels, (s,v)=>s.has(v), c)}
-                  className={`px-3 py-1.5 rounded-full border text-sm transition ${inSet(channels, c) ? "bg-neutral-900 text-white border-neutral-900" : "bg-white text-neutral-700 border-neutral-300 hover:border-neutral-400 dark:bg-neutral-800 dark:text-neutral-100 dark:border-neutral-700"}`}>
+                <button
+                  key={c}
+                  onClick={() => toggleSet(setChannels, (s, v) => s.has(v), c)}
+                  className={`px-2.5 py-1 rounded-full text-xs font-medium transition ${
+                    inSet(channels, c)
+                      ? "bg-neutral-900 text-white shadow-sm dark:bg-neutral-100 dark:text-neutral-900"
+                      : "bg-neutral-100 text-neutral-600 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700/70"
+                  }`}
+                >
                   {c}
                 </button>
               ))}
             </div>
           </div>
-          <div className="rounded-2xl border border-neutral-200 bg-white p-3 dark:bg-neutral-900 dark:border-neutral-800">
-            <div className="text-sm font-medium mb-2 text-neutral-700 dark:text-neutral-200">Filter Marketplace</div>
-            <div className="flex flex-wrap gap-2">
+          <div className="rounded-2xl border border-neutral-200 bg-white p-3 sm:p-4 dark:bg-neutral-900 dark:border-neutral-800">
+            <div className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400 mb-2">
+              Marketplace
+            </div>
+            <div className="flex flex-wrap gap-1.5">
               {allMarketplaces.map((m) => (
-                <button key={m} onClick={() => toggleSet(setMarketplaces, (s,v)=>s.has(v), m)}
-                  className={`px-3 py-1.5 rounded-full border text-sm transition ${inSet(marketplaces, m) ? "bg-neutral-900 text-white border-neutral-900" : "bg-white text-neutral-700 border-neutral-300 hover:border-neutral-400 dark:bg-neutral-800 dark:text-neutral-100 dark:border-neutral-700"}`}>
+                <button
+                  key={m}
+                  onClick={() => toggleSet(setMarketplaces, (s, v) => s.has(v), m)}
+                  className={`px-2.5 py-1 rounded-full text-xs font-medium transition ${
+                    inSet(marketplaces, m)
+                      ? "bg-neutral-900 text-white shadow-sm dark:bg-neutral-100 dark:text-neutral-900"
+                      : "bg-neutral-100 text-neutral-600 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700/70"
+                  }`}
+                >
                   {m}
                 </button>
               ))}
@@ -344,16 +363,17 @@ export default function IndexPage() {
 
       {/* KPI cards */}
       <div className="max-w-7xl mx-auto px-4">
-        <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className="grid sm:grid-cols-2 lg:grid-cols-5 gap-4">
           <KPI title="Penjualan (Gross)" value={fmtIDR(totals.penjualan)} sub={"Diskon " + fmtIDR(totals.diskon)} />
           <KPI title="Penjualan Net" value={fmtIDR(totals.penjualanNet)} sub={"Qty " + fmtNum(totals.qty)} />
           <KPI title="Total Biaya" value={fmtIDR(totals.totalBiaya)} sub={`Modal ${fmtIDR(totals.modal)}`} />
-          <KPI title="Laba" value={fmtIDR(totals.laba)} sub={`Margin ${(totals.margin * 100).toFixed(1)}% • ROAS ${totals.roas.toFixed(2)}x`} />
+          <KPI title="Total Biaya Iklan" value={fmtIDR(totals.biayaIklan)} sub={`ROAS ${totals.roas.toFixed(2)}x`} />
+          <KPI title="Laba" value={fmtIDR(totals.laba)} sub={`Margin ${(totals.margin * 100).toFixed(1)}%`} />
         </div>
       </div>
 
       {/* Main Charts */}
-      <div className="max-w-7xl mx-auto px-4 py-6 grid lg:grid-cols-3 gap-4">
+      <div className="max-w-7xl mx-auto px-4 py-6 grid lg:grid-cols-4 gap-4">
         <div className="rounded-2xl border border-neutral-200 bg-white p-4 lg:col-span-2 dark:bg-neutral-900 dark:border-neutral-800">
           <div className="text-sm font-medium mb-3 text-neutral-700 dark:text-neutral-200">Pendapatan Net vs Total Biaya (Harian)</div>
           <div className="h-[42vh] sm:h-72">
@@ -387,8 +407,29 @@ export default function IndexPage() {
           </div>
         </div>
         <div className="rounded-2xl border border-neutral-200 bg-white p-4 dark:bg-neutral-900 dark:border-neutral-800">
+          <div className="text-sm font-medium mb-3 text-neutral-700 dark:text-neutral-200">Laba Harian</div>
+          <div className="h-[42vh] sm:h-72">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={daily}>
+                <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
+                <XAxis dataKey="date" tick={axisTickStyle} tickLine={false} axisLine={false} />
+                <YAxis
+                  tickFormatter={formatAxisValue}
+                  tick={axisTickStyle}
+                  width={80}
+                  axisLine={false}
+                  tickLine={false}
+                />
+                <Tooltip formatter={(v) => fmtIDR(v)} contentStyle={tooltipStyle} itemStyle={tooltipItemStyle} />
+                <Legend wrapperStyle={legendStyle} />
+                <Line type="monotone" dataKey="laba" name="Laba" stroke={chartColors.profit} strokeWidth={2} dot={false} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+        <div className="rounded-2xl border border-neutral-200 bg-white p-4 dark:bg-neutral-900 dark:border-neutral-800">
           <div className="text-sm font-medium mb-3 text-neutral-700 dark:text-neutral-200">Breakdown Biaya</div>
-          <div className="h-[36vh] sm:h-72">
+          <div className="h-[42vh] sm:h-72">
             <ResponsiveContainer width="100%" height="100%">
               <PieChart>
                 <Pie data={pieData} dataKey="value" nameKey="name" outerRadius={90}>

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,7 +6,6 @@ import {
   BarChart, Bar, LineChart, Line, PieChart, Pie, Cell
 } from "recharts";
 
-const allChannels = ["Website", "Shopee", "Tokopedia"];
 const allMarketplaces = ["Website", "Shopee", "Tokopedia"];
 
 const fmtIDR = (n) =>
@@ -123,7 +122,6 @@ export default function IndexPage() {
   // Filters
   const [dateFrom, setDateFrom] = useState(() => { const d = new Date(); d.setDate(d.getDate() - 14); return d.toISOString().slice(0,10); });
   const [dateTo, setDateTo] = useState(() => new Date().toISOString().slice(0,10));
-  const [channels, setChannels] = useState(new Set(allChannels));
   const [marketplaces, setMarketplaces] = useState(new Set(allMarketplaces));
 
   useEffect(() => { const k = localStorage.getItem('AKAY_ADMIN_KEY') || ''; if (k) setAdminKey(k); }, []);
@@ -146,8 +144,8 @@ export default function IndexPage() {
   const filtered = useMemo(() => rows.filter(r => {
     const t = new Date(r.date);
     const min = new Date(dateFrom); const max = new Date(dateTo); max.setHours(23,59,59,999);
-    return t >= min && t <= max && channels.has(r.channel) && marketplaces.has(r.marketplace);
-  }), [rows, dateFrom, dateTo, channels, marketplaces]);
+    return t >= min && t <= max && marketplaces.has(r.marketplace);
+  }), [rows, dateFrom, dateTo, marketplaces]);
 
   const daily = useMemo(() => groupByDate(filtered), [filtered]);
 
@@ -312,14 +310,6 @@ export default function IndexPage() {
                   Menu
                 </button>
               </div>
-              <div className="flex flex-col gap-1 rounded-2xl bg-white/40 px-3 py-2 shadow-sm ring-1 ring-neutral-200 md:flex-row md:items-center md:gap-3 dark:bg-neutral-900/50 dark:ring-neutral-800">
-                <div className="text-base font-semibold text-neutral-800 dark:text-neutral-100">Helo Admin</div>
-                <div className="flex flex-col gap-1 text-sm text-neutral-500 capitalize md:flex-row md:items-center md:gap-3 dark:text-neutral-400">
-                  <span>{formattedDate}</span>
-                  <span className="hidden h-3 w-px bg-neutral-300 md:inline-block dark:bg-neutral-700" aria-hidden="true"></span>
-                  <span className="font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">{formattedTime}</span>
-                </div>
-              </div>
             </div>
             {/* Control groups */}
             <div
@@ -354,24 +344,20 @@ export default function IndexPage() {
       {/* Filters */}
       <div className="max-w-7xl mx-auto px-4 py-3">
         <div className="grid md:grid-cols-2 gap-3">
-          <div className="rounded-2xl border border-neutral-200 bg-white p-3 sm:p-4 dark:bg-neutral-900 dark:border-neutral-800">
-            <div className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400 mb-2">
-              Channel
-            </div>
-            <div className="flex flex-wrap gap-1.5">
-              {allChannels.map((c) => (
-                <button
-                  key={c}
-                  onClick={() => toggleSet(setChannels, (s, v) => s.has(v), c)}
-                  className={`px-2.5 py-1 rounded-full text-xs font-medium transition ${
-                    inSet(channels, c)
-                      ? "bg-neutral-900 text-white shadow-sm dark:bg-neutral-100 dark:text-neutral-900"
-                      : "bg-neutral-100 text-neutral-600 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700/70"
-                  }`}
-                >
-                  {c}
-                </button>
-              ))}
+          <div className="rounded-2xl border border-neutral-200 bg-white p-4 dark:bg-neutral-900 dark:border-neutral-800">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <div className="text-sm font-semibold text-neutral-800 dark:text-neutral-100">Helo Admin</div>
+                <div className="mt-1 text-xs font-medium uppercase tracking-wide text-neutral-400 dark:text-neutral-500">
+                  Ringkasan dashboard
+                </div>
+              </div>
+              <div className="flex flex-col items-start gap-1 text-sm text-neutral-600 capitalize sm:items-end sm:text-right dark:text-neutral-300">
+                <span>{formattedDate}</span>
+                <span className="text-base font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">
+                  {formattedTime}
+                </span>
+              </div>
             </div>
           </div>
           <div className="rounded-2xl border border-neutral-200 bg-white p-3 sm:p-4 dark:bg-neutral-900 dark:border-neutral-800">

--- a/pages/index.js
+++ b/pages/index.js
@@ -65,6 +65,7 @@ export default function IndexPage() {
   const [replaceOnImport, setReplaceOnImport] = useState(true);
   const [adminKey, setAdminKey] = useState('');
   const [isAdmin, setIsAdmin] = useState(false);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   // THEME (light/dark)
   const [theme, setTheme] = useState('light');
@@ -213,15 +214,30 @@ export default function IndexPage() {
           {/* Responsive header layout */}
           <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
             {/* Brand */}
-            <div className="flex items-center gap-3">
-              <img src="/akay-logo.svg" alt="AKAY" className="w-9 h-9 rounded" />
-              <div>
-                <h1 className="text-xl font-semibold leading-tight">AKAY Sales Dashboard</h1>
-                <p className="text-xs text-neutral-500 dark:text-neutral-400">Google Sheets ↔ Next.js • Admin/Viewer • Export</p>
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <img src="/akay-logo.svg" alt="AKAY" className="w-9 h-9 rounded" />
+                <div>
+                  <h1 className="text-xl font-semibold leading-tight">AKAY Sales Dashboard</h1>
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400">Google Sheets ↔ Next.js • Admin/Viewer • Export</p>
+                </div>
               </div>
+              <button
+                type="button"
+                onClick={() => setMobileMenuOpen((prev) => !prev)}
+                className="md:hidden inline-flex items-center gap-2 px-3 py-2 rounded-full border border-neutral-300 text-sm font-medium text-neutral-700 hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-100 dark:bg-neutral-900"
+                aria-expanded={mobileMenuOpen}
+                aria-controls="dashboard-controls"
+              >
+                <span className="text-lg" aria-hidden="true">☰</span>
+                Menu
+              </button>
             </div>
             {/* Control groups */}
-            <div className="grid gap-2 sm:grid-cols-2 md:flex md:flex-wrap md:items-center md:gap-2">
+            <div
+              id="dashboard-controls"
+              className={`${mobileMenuOpen ? "flex" : "hidden"} flex-col gap-3 md:flex md:flex-row md:items-center md:justify-between md:gap-4`}
+            >
               {/* Date group */}
               <div className="flex flex-col sm:flex-row sm:items-center gap-2">
                 <div className="flex items-center gap-2">

--- a/pages/index.js
+++ b/pages/index.js
@@ -302,9 +302,6 @@ export default function IndexPage() {
               </div>
               {/* Action group */}
               <div className="flex flex-wrap items-center gap-2">
-                <button onClick={()=>doExport('csv')} className="w-full sm:w-auto px-3 py-1.5 rounded-full border text-sm bg-white hover:bg-neutral-50 dark:bg-neutral-800 dark:text-neutral-100 dark:border-neutral-700">CSV</button>
-                <button onClick={()=>doExport('xlsx')} className="w-full sm:w-auto px-3 py-1.5 rounded-full border text-sm bg-white hover:bg-neutral-50 dark:bg-neutral-800 dark:text-neutral-100 dark:border-neutral-700">XLSX</button>
-                <button onClick={()=>doExport('pdf')} className="w-full sm:w-auto px-3 py-1.5 rounded-full border text-sm bg-white hover:bg-neutral-50 dark:bg-neutral-800 dark:text-neutral-100 dark:border-neutral-700">PDF</button>
                 <button onClick={toggleTheme} className="w-full sm:w-auto px-3 py-1.5 rounded-full border text-sm bg-white hover:bg-neutral-50 dark:bg-neutral-800 dark:text-neutral-100 dark:border-neutral-700" title="Ganti tema">
                   {theme === 'dark' ? '☀️ Terang' : '🌙 Gelap'}
                 </button>
@@ -477,16 +474,23 @@ export default function IndexPage() {
         <div className="rounded-2xl border border-neutral-200 bg-white overflow-hidden dark:bg-neutral-900 dark:border-neutral-800">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between px-4 py-3 border-b gap-2 dark:border-neutral-800">
             <div className="text-sm font-medium text-neutral-700 dark:text-neutral-200">Rangkuman Harian</div>
-            <div className="grid grid-cols-1 sm:grid-cols-3 md:flex md:flex-wrap items-center gap-2 w-full md:w-auto">
+            <div className="flex flex-col gap-2 w-full lg:flex-row lg:items-center lg:justify-between">
               <label className="flex items-center gap-2 text-sm text-neutral-600 dark:text-neutral-300">
                 <input type="checkbox" checked={replaceOnImport} onChange={(e) => setReplaceOnImport(e.target.checked)} />
                 Ganti data saat import CSV
               </label>
-              <label className="text-sm px-3 py-1.5 rounded-full bg-neutral-900 text-white cursor-pointer dark:bg-neutral-200 dark:text-neutral-900 text-center">
-                Import CSV
-                <input type="file" accept=".csv" className="hidden" onChange={(e)=>{ const f = e.target.files?.[0]; if (f) onImportCSV(f); }} />
-              </label>
-              <div className="flex gap-2">
+              <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+                <div className="flex flex-wrap sm:flex-nowrap gap-2">
+                  <button onClick={()=>doExport('csv')} className="w-full sm:w-auto px-3 py-1.5 rounded-full border text-sm bg-white hover:bg-neutral-50 dark:bg-neutral-800 dark:text-neutral-100 dark:border-neutral-700">CSV</button>
+                  <button onClick={()=>doExport('xlsx')} className="w-full sm:w-auto px-3 py-1.5 rounded-full border text-sm bg-white hover:bg-neutral-50 dark:bg-neutral-800 dark:text-neutral-100 dark:border-neutral-700">XLSX</button>
+                  <button onClick={()=>doExport('pdf')} className="w-full sm:w-auto px-3 py-1.5 rounded-full border text-sm bg-white hover:bg-neutral-50 dark:bg-neutral-800 dark:text-neutral-100 dark:border-neutral-700">PDF</button>
+                </div>
+                <label className="inline-flex items-center justify-center text-sm px-3 py-1.5 rounded-full bg-neutral-900 text-white cursor-pointer dark:bg-neutral-200 dark:text-neutral-900 text-center">
+                  Import CSV
+                  <input type="file" accept=".csv" className="hidden" onChange={(e)=>{ const f = e.target.files?.[0]; if (f) onImportCSV(f); }} />
+                </label>
+              </div>
+              <div className="flex flex-col sm:flex-row gap-2 w-full lg:w-auto">
                 <input placeholder="Admin API Key" value={adminKey} onChange={(e)=>setAdminKey(e.target.value)} className="flex-1 px-2 py-1 rounded border border-neutral-300 text-sm dark:bg-neutral-800 dark:border-neutral-700" />
                 <button onClick={loginAdmin} className="px-3 py-1.5 rounded-full border text-sm bg-white hover:bg-neutral-50 dark:bg-neutral-800 dark:text-neutral-100 dark:border-neutral-700">Login Admin</button>
               </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,6 @@
 
 import React, { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 import { motion } from "framer-motion";
 import {
   ResponsiveContainer, AreaChart, Area, CartesianGrid, XAxis, YAxis, Tooltip, Legend,
@@ -328,6 +329,12 @@ export default function IndexPage() {
               </div>
               {/* Action group */}
               <div className="flex flex-wrap items-center gap-2">
+                <Link
+                  href="/warehouse"
+                  className="w-full sm:w-auto rounded-full border border-neutral-300 bg-white px-3 py-1.5 text-sm font-medium text-neutral-700 hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-100"
+                >
+                  Gudang
+                </Link>
                 <button onClick={toggleTheme} className="w-full sm:w-auto px-3 py-1.5 rounded-full border text-sm bg-white hover:bg-neutral-50 dark:bg-neutral-800 dark:text-neutral-100 dark:border-neutral-700" title="Ganti tema">
                   {theme === 'dark' ? '☀️ Terang' : '🌙 Gelap'}
                 </button>

--- a/pages/index.js
+++ b/pages/index.js
@@ -296,7 +296,6 @@ export default function IndexPage() {
                   <img src="/akay-logo.svg" alt="AKAY" className="w-9 h-9 rounded" />
                   <div>
                     <h1 className="text-xl font-semibold leading-tight">AKAY Sales Dashboard</h1>
-                    <p className="text-xs text-neutral-500 dark:text-neutral-400">Google Sheets ↔ Next.js • Admin/Viewer • Export</p>
                   </div>
                 </div>
                 <button

--- a/pages/index.js
+++ b/pages/index.js
@@ -152,6 +152,16 @@ export default function IndexPage() {
     { name: "Lainnya", value: totals.biayaLainnya },
   ], [totals]);
 
+  const adSpendByChannel = useMemo(() => {
+    const map = new Map();
+    filtered.forEach((row) => {
+      const channel = row.channel || "Lainnya";
+      const current = map.get(channel) || 0;
+      map.set(channel, current + parseNumber(row.biayaIklan));
+    });
+    return Array.from(map.entries()).map(([name, value]) => ({ name, value })).sort((a, b) => b.value - a.value);
+  }, [filtered]);
+
   const toggleSet = (setState, hasFn, value) => { setState((prev) => { const next = new Set(prev); if (hasFn(prev, value)) next.delete(value); else next.add(value); return next; }); };
   const inSet = (set, value) => set.has(value);
 
@@ -323,7 +333,7 @@ export default function IndexPage() {
       </div>
 
       {/* New Charts: Ad Spend & Marketplace Deductions */}
-      <div className="max-w-7xl mx-auto px-4 pb-6 grid md:grid-cols-2 gap-4">
+      <div className="max-w-7xl mx-auto px-4 pb-6 grid md:grid-cols-2 xl:grid-cols-3 gap-4">
         <div className="rounded-2xl border border-neutral-200 bg-white p-4 dark:bg-neutral-900 dark:border-neutral-800">
           <div className="text-sm font-medium mb-3 text-neutral-700 dark:text-neutral-200">Pengeluaran Iklan (Harian)</div>
           <div className="h-[36vh] sm:h-64">
@@ -350,6 +360,21 @@ export default function IndexPage() {
                 <Tooltip formatter={(v) => fmtIDR(v)} />
                 <Legend />
                 <Bar dataKey="potonganMarketplace" name="Potongan MP" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+        <div className="rounded-2xl border border-neutral-200 bg-white p-4 dark:bg-neutral-900 dark:border-neutral-800">
+          <div className="text-sm font-medium mb-3 text-neutral-700 dark:text-neutral-200">Biaya Iklan per Channel</div>
+          <div className="h-[36vh] sm:h-64">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={adSpendByChannel}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis tickFormatter={(v) => fmtNum(v / 1000) + "k"} />
+                <Tooltip formatter={(v) => fmtIDR(v)} />
+                <Legend />
+                <Bar dataKey="value" name="Biaya Iklan" fill="#f97316" />
               </BarChart>
             </ResponsiveContainer>
           </div>

--- a/pages/login.js
+++ b/pages/login.js
@@ -3,11 +3,13 @@ import { useEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
 
 export default function Login() {
+  const TYPEWRITER_TEXT = "AKAY DIGITAL NUSANTARA";
   const [username, setUsername] = useState("admin");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const vantaRef = useRef(null);
+  const [typedText, setTypedText] = useState("");
 
   const submit = async (e) => {
     e.preventDefault();
@@ -100,20 +102,54 @@ export default function Login() {
     };
   }, []);
 
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    let index = 0;
+    const fullText = TYPEWRITER_TEXT;
+
+    const interval = window.setInterval(() => {
+      index += 1;
+      setTypedText(fullText.slice(0, index));
+
+      if (index >= fullText.length) {
+        window.clearInterval(interval);
+      }
+    }, 120);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [TYPEWRITER_TEXT]);
+
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#050315] text-white">
       <div ref={vantaRef} className="pointer-events-none absolute inset-0" />
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(244,114,182,0.25),transparent_55%),radial-gradient(circle_at_80%_30%,rgba(59,130,246,0.18),transparent_45%),radial-gradient(circle_at_50%_80%,rgba(129,140,248,0.2),transparent_50%)] mix-blend-screen" />
       <div className="pointer-events-none absolute inset-0 bg-noise opacity-20" />
 
-      {/* Login card */}
-      <div className="relative z-10 flex min-h-screen items-center justify-center px-4 md:justify-end md:px-12">
+      {/* Login layout */}
+      <div className="relative z-10 flex min-h-screen flex-col items-center justify-center gap-16 px-4 py-16 text-center md:flex-row md:items-center md:justify-between md:px-12 md:text-left">
+        <div className="max-w-xl space-y-4">
+          <p className="text-sm uppercase tracking-[0.4em] text-white/60">Welcome</p>
+          <div className="flex items-center justify-center gap-2 md:justify-start">
+            <h2 className="text-4xl font-semibold leading-tight text-white sm:text-5xl lg:text-6xl">
+              {typedText}
+            </h2>
+            <span className="mt-2 h-7 w-[3px] animate-pulse rounded-full bg-white/80 sm:h-9" aria-hidden />
+          </div>
+          <p className="text-base text-white/70 sm:text-lg">
+            Transforming data into decisive actions for your business growth.
+          </p>
+        </div>
         <motion.form
           onSubmit={submit}
           initial={{ y: 12, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
           transition={{ duration: 0.5 }}
-          className="w-full max-w-sm rounded-2xl border border-white/10 bg-white/5 backdrop-blur-xl p-6 shadow-2xl md:mr-4 lg:mr-12"
+          className="w-full max-w-sm rounded-2xl border border-white/10 bg-white/5 p-6 shadow-2xl backdrop-blur-xl"
         >
           {/* Brand */}
           <div className="mb-4 flex items-center gap-3">
@@ -161,7 +197,7 @@ export default function Login() {
           </button>
 
           <div className="mt-3 text-center text-xs text-neutral-400">
-            Set ENV <code>ADMIN_UI_USER</code>, <code>ADMIN_UI_PASSWORD</code>, <code>SESSION_SECRET</code>
+            Develop by <span className="font-medium text-neutral-200">@mungwongsepele</span> @2025
           </div>
         </motion.form>
       </div>

--- a/pages/login.js
+++ b/pages/login.js
@@ -31,33 +31,46 @@ export default function Login() {
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-neutral-950 text-white">
-      {/* Animated gradient blobs */}
+      {/* Animated line accents */}
       <motion.div
         aria-hidden
-        className="pointer-events-none absolute -top-32 -left-32 h-[36rem] w-[36rem] rounded-full blur-3xl"
-        initial={{ opacity: 0.4, scale: 0.9 }}
-        animate={{ opacity: 0.7, scale: 1.05, x: [0, 30, -20, 0], y: [0, -10, 20, 0] }}
-        transition={{ duration: 16, repeat: Infinity, ease: "easeInOut" }}
-        style={{ background: "radial-gradient(closest-side, rgba(120,119,198,0.6), rgba(120,119,198,0) 70%)" }}
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundImage:
+            "repeating-linear-gradient(110deg, rgba(56,189,248,0.22) 0px, rgba(56,189,248,0.22) 2px, transparent 2px, transparent 140px)",
+          maskImage: "linear-gradient(to bottom, transparent 5%, black 20%, black 80%, transparent 95%)",
+          WebkitMaskImage: "linear-gradient(to bottom, transparent 5%, black 20%, black 80%, transparent 95%)",
+        }}
+        initial={{ opacity: 0.15, backgroundPosition: "0% 0%" }}
+        animate={{ opacity: 0.3, backgroundPosition: ["0% 0%", "200% 100%"] }}
+        transition={{ duration: 24, repeat: Infinity, ease: "linear" }}
       />
       <motion.div
         aria-hidden
-        className="pointer-events-none absolute -bottom-40 -right-40 h-[40rem] w-[40rem] rounded-full blur-3xl"
-        initial={{ opacity: 0.35, scale: 0.9 }}
-        animate={{ opacity: 0.6, scale: 1.08, x: [0, -20, 35, 0], y: [0, 25, -15, 0] }}
-        transition={{ duration: 18, repeat: Infinity, ease: "easeInOut" }}
-        style={{ background: "radial-gradient(closest-side, rgba(34,197,94,0.5), rgba(34,197,94,0) 70%)" }}
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundImage:
+            "repeating-linear-gradient(250deg, rgba(167,139,250,0.18) 0px, rgba(167,139,250,0.18) 2px, transparent 2px, transparent 120px)",
+          maskImage: "linear-gradient(to right, transparent 10%, black 30%, black 70%, transparent 90%)",
+          WebkitMaskImage: "linear-gradient(to right, transparent 10%, black 30%, black 70%, transparent 90%)",
+        }}
+        initial={{ opacity: 0.1, backgroundPosition: "0% 100%" }}
+        animate={{ opacity: 0.22, backgroundPosition: ["0% 100%", "-180% -40%"] }}
+        transition={{ duration: 28, repeat: Infinity, ease: "linear" }}
       />
 
-      {/* Subtle animated grid overlay */}
-      <div className="absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.06)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.06)_1px,transparent_1px)] bg-[size:24px_24px] opacity-30" />
+      {/* Pulsing partial horizontal lines */}
       <motion.div
         aria-hidden
-        className="absolute inset-0"
-        initial={{ backgroundPositionX: 0 }}
-        animate={{ backgroundPositionX: ["0px", "48px", "0px"] }}
-        transition={{ duration: 20, repeat: Infinity, ease: "linear" }}
-        style={{ backgroundImage: "linear-gradient(to right, rgba(255,255,255,0.05) 1px, transparent 1px)", backgroundSize: "48px 100%", mixBlendMode: "overlay" }}
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundImage:
+            "linear-gradient(to bottom, transparent 0%, transparent 40%, rgba(255,255,255,0.12) 45%, transparent 50%, transparent 100%)",
+          backgroundSize: "100% 120px",
+        }}
+        initial={{ opacity: 0.05, backgroundPositionY: 0 }}
+        animate={{ opacity: [0.05, 0.18, 0.05], backgroundPositionY: [0, 60, 120, 0] }}
+        transition={{ duration: 16, repeat: Infinity, ease: "easeInOut" }}
       />
 
       {/* Noise layer */}

--- a/pages/login.js
+++ b/pages/login.js
@@ -107,20 +107,42 @@ export default function Login() {
       return undefined;
     }
 
-    let index = 0;
     const fullText = TYPEWRITER_TEXT;
+    let currentLength = 0;
+    let isDeleting = false;
+    let timeoutId = null;
 
-    const interval = window.setInterval(() => {
-      index += 1;
-      setTypedText(fullText.slice(0, index));
+    const tick = () => {
+      if (!isDeleting) {
+        currentLength += 1;
+        setTypedText(fullText.slice(0, currentLength));
 
-      if (index >= fullText.length) {
-        window.clearInterval(interval);
+        if (currentLength === fullText.length) {
+          isDeleting = true;
+          timeoutId = window.setTimeout(tick, 1400);
+          return;
+        }
+      } else {
+        currentLength = Math.max(0, currentLength - 1);
+        setTypedText(fullText.slice(0, currentLength));
+
+        if (currentLength === 0) {
+          isDeleting = false;
+          timeoutId = window.setTimeout(tick, 500);
+          return;
+        }
       }
-    }, 120);
+
+      const delay = isDeleting ? 60 : 120;
+      timeoutId = window.setTimeout(tick, delay);
+    };
+
+    timeoutId = window.setTimeout(tick, 400);
 
     return () => {
-      window.clearInterval(interval);
+      if (timeoutId) {
+        window.clearTimeout(timeoutId);
+      }
     };
   }, [TYPEWRITER_TEXT]);
 

--- a/pages/login.js
+++ b/pages/login.js
@@ -106,14 +106,14 @@ export default function Login() {
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(244,114,182,0.25),transparent_55%),radial-gradient(circle_at_80%_30%,rgba(59,130,246,0.18),transparent_45%),radial-gradient(circle_at_50%_80%,rgba(129,140,248,0.2),transparent_50%)] mix-blend-screen" />
       <div className="pointer-events-none absolute inset-0 bg-noise opacity-20" />
 
-      {/* Centered card */}
-      <div className="relative z-10 grid min-h-screen place-items-center px-4">
+      {/* Login card */}
+      <div className="relative z-10 flex min-h-screen items-center justify-center px-4 md:justify-end md:px-12">
         <motion.form
           onSubmit={submit}
           initial={{ y: 12, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
           transition={{ duration: 0.5 }}
-          className="w-full max-w-sm rounded-2xl border border-white/10 bg-white/5 backdrop-blur-xl p-6 shadow-2xl"
+          className="w-full max-w-sm rounded-2xl border border-white/10 bg-white/5 backdrop-blur-xl p-6 shadow-2xl md:mr-4 lg:mr-12"
         >
           {/* Brand */}
           <div className="mb-4 flex items-center gap-3">

--- a/pages/warehouse/index.js
+++ b/pages/warehouse/index.js
@@ -1,0 +1,426 @@
+import React, { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+
+const now = () => new Date();
+
+const quickStats = [
+  { title: "Total SKU Aktif", value: 124, trend: "+8 SKU", tone: "positive" },
+  { title: "Stok Minimum", value: "37 SKU", trend: "Perlu restock", tone: "warning" },
+  { title: "Barang Masuk Hari Ini", value: "1.240 unit", trend: "+12% vs kemarin", tone: "positive" },
+  { title: "Barang Keluar Hari Ini", value: "980 unit", trend: "-5% vs kemarin", tone: "neutral" },
+  { title: "Stock Opname Terakhir", value: "12 Feb 2025", trend: "Gudang Utama", tone: "neutral" },
+];
+
+const stockAlerts = [
+  { sku: "AK-0912", name: "Serum Bright 30ml", status: "Stok menipis", location: "Rak A3", priority: "high" },
+  { sku: "AK-4551", name: "Masker Charcoal", status: "Overstock", location: "Rak B1", priority: "medium" },
+  { sku: "AK-7710", name: "Toner Herbal", status: "Menunggu QC", location: "Area Karantina", priority: "low" },
+];
+
+const inboundOutbound = [
+  { type: "Inbound", reference: "PO-2025-091", time: "08:15", by: "Maya", notes: "Supplier Herbal Co", qty: "+320" },
+  { type: "Outbound", reference: "SO-2025-233", time: "10:22", by: "Rangga", notes: "Marketplace Tokopedia", qty: "-180" },
+  { type: "Inbound", reference: "PO-2025-094", time: "13:05", by: "Yuda", notes: "Supplier GlowUp", qty: "+420" },
+  { type: "Outbound", reference: "SO-2025-240", time: "15:40", by: "Laras", notes: "Website", qty: "-260" },
+];
+
+const locationMap = [
+  { zone: "Gudang Utama", racks: "Rak A1-A8", filled: 82, capacity: 96 },
+  { zone: "Gudang Pending", racks: "Rak B1-B6", filled: 45, capacity: 60 },
+  { zone: "Area QC", racks: "C1-C3", filled: 12, capacity: 24 },
+  { zone: "Area Ekspedisi", racks: "D1-D2", filled: 9, capacity: 12 },
+];
+
+const users = [
+  { name: "Hadi", role: "Kepala Gudang", status: "Aktif", shift: "Pagi" },
+  { name: "Maya", role: "Admin Stok", status: "Aktif", shift: "Pagi" },
+  { name: "Rangga", role: "Picker", status: "Aktif", shift: "Siang" },
+  { name: "Dina", role: "Checker", status: "Cuti", shift: "Malam" },
+];
+
+const reports = [
+  { title: "Ringkasan Stok Mingguan", period: "5-11 Feb 2025", status: "Siap unduh" },
+  { title: "Laporan Barang Masuk", period: "Februari 2025", status: "Dijadwalkan" },
+  { title: "Laporan Barang Keluar", period: "Februari 2025", status: "Diproses" },
+];
+
+const opnamePlans = [
+  { area: "Rak A1-A4", schedule: "15 Feb 2025", supervisor: "Hadi", status: "Terjadwal" },
+  { area: "Rak B1-B6", schedule: "16 Feb 2025", supervisor: "Maya", status: "Terjadwal" },
+  { area: "Area Pending", schedule: "17 Feb 2025", supervisor: "Dina", status: "Menunggu" },
+];
+
+const notifications = [
+  { time: "Baru saja", message: "Stok Serum Bright tinggal 24 unit.", tone: "critical" },
+  { time: "10 menit lalu", message: "Inbound PO-2025-094 selesai diproses.", tone: "success" },
+  { time: "30 menit lalu", message: "Pengingat opname Rak A1-A4 besok pukul 09.00.", tone: "info" },
+];
+
+const classNames = (...args) => args.filter(Boolean).join(" ");
+
+const toneStyles = {
+  positive: "text-emerald-600 dark:text-emerald-400",
+  warning: "text-amber-600 dark:text-amber-400",
+  neutral: "text-neutral-500 dark:text-neutral-400",
+  success: "text-emerald-600 dark:text-emerald-400",
+  info: "text-sky-600 dark:text-sky-400",
+  critical: "text-rose-600 dark:text-rose-400",
+};
+
+export default function WarehousePage() {
+  const [theme, setTheme] = useState("light");
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [clock, setClock] = useState(() => now());
+
+  useEffect(() => {
+    const saved =
+      typeof window !== "undefined"
+        ? localStorage.getItem("AKAY_THEME") ||
+          (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light")
+        : "light";
+    setTheme(saved);
+    document.documentElement.classList.toggle("dark", saved === "dark");
+  }, []);
+
+  const toggleTheme = () => {
+    setTheme((prev) => {
+      const next = prev === "dark" ? "light" : "dark";
+      if (typeof window !== "undefined") {
+        localStorage.setItem("AKAY_THEME", next);
+        document.documentElement.classList.toggle("dark", next === "dark");
+      }
+      return next;
+    });
+  };
+
+  useEffect(() => {
+    const timer = setInterval(() => setClock(now()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const currentTime = useMemo(
+    () =>
+      new Intl.DateTimeFormat("id-ID", {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      }).format(clock),
+    [clock]
+  );
+
+  const currentDate = useMemo(() => {
+    const formatted = new Intl.DateTimeFormat("id-ID", {
+      weekday: "long",
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    }).format(clock);
+    return formatted.charAt(0).toUpperCase() + formatted.slice(1);
+  }, [clock]);
+
+  return (
+    <div className="min-h-screen bg-neutral-50 text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
+      <header className="sticky top-0 z-30 border-b border-neutral-200 bg-white/80 backdrop-blur dark:border-neutral-800 dark:bg-neutral-900/80">
+        <div className="mx-auto flex max-w-7xl flex-col gap-3 px-4 py-4 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <img src="/akay-logo.svg" alt="AKAY" className="h-9 w-9 rounded" />
+              <div>
+                <h1 className="text-xl font-semibold leading-tight">AKAY Warehouse Hub</h1>
+                <p className="text-sm text-neutral-500 dark:text-neutral-400">Integrasi stok & fulfillment</p>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => setMobileMenuOpen((prev) => !prev)}
+              className="inline-flex items-center gap-2 rounded-full border border-neutral-300 px-3 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-100 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 md:hidden"
+              aria-expanded={mobileMenuOpen}
+              aria-controls="warehouse-controls"
+            >
+              <span aria-hidden="true" className="text-lg">
+                ☰
+              </span>
+              Menu
+            </button>
+          </div>
+          <nav
+            id="warehouse-controls"
+            className={classNames(
+              "flex flex-col gap-3 md:flex md:flex-row md:items-center md:gap-4",
+              mobileMenuOpen ? "flex" : "hidden"
+            )}
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <Link
+                href="/"
+                className="rounded-full border border-neutral-200 px-3 py-1.5 text-sm font-medium text-neutral-600 hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800"
+              >
+                ← Kembali ke Sales
+              </Link>
+              <button
+                type="button"
+                onClick={toggleTheme}
+                className="rounded-full border border-neutral-200 px-3 py-1.5 text-sm font-medium text-neutral-600 hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800"
+              >
+                {theme === "dark" ? "☀️ Terang" : "🌙 Gelap"}
+              </button>
+            </div>
+            <div className="flex flex-col gap-1 text-sm text-neutral-500 dark:text-neutral-400 md:items-end">
+              <span>{currentDate}</span>
+              <span className="text-base font-semibold text-neutral-900 dark:text-neutral-100">{currentTime}</span>
+            </div>
+          </nav>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-7xl space-y-6 px-4 py-6">
+        <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
+          {quickStats.map((item) => (
+            <article
+              key={item.title}
+              className="rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900"
+            >
+              <h2 className="text-sm font-semibold text-neutral-500 dark:text-neutral-400">{item.title}</h2>
+              <p className="mt-3 text-2xl font-semibold text-neutral-900 dark:text-neutral-50">{item.value}</p>
+              <span className={classNames("mt-2 block text-xs font-medium", toneStyles[item.tone])}>{item.trend}</span>
+            </article>
+          ))}
+        </section>
+
+        <section className="grid gap-4 lg:grid-cols-5">
+          <article className="rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900 lg:col-span-3">
+            <div className="flex items-start justify-between">
+              <div>
+                <h2 className="text-lg font-semibold">Data Barang</h2>
+                <p className="text-sm text-neutral-500 dark:text-neutral-400">Ringkasan SKU aktif & status stok realtime</p>
+              </div>
+              <button className="rounded-full border border-neutral-200 px-3 py-1 text-xs font-medium text-neutral-600 hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800">
+                Unduh CSV
+              </button>
+            </div>
+            <div className="mt-4 overflow-hidden rounded-xl border border-neutral-200 dark:border-neutral-800">
+              <table className="min-w-full divide-y divide-neutral-200 text-sm dark:divide-neutral-800">
+                <thead className="bg-neutral-100 text-left uppercase tracking-wide text-xs font-semibold text-neutral-500 dark:bg-neutral-800/60 dark:text-neutral-300">
+                  <tr>
+                    <th className="px-4 py-3">SKU</th>
+                    <th className="px-4 py-3">Nama</th>
+                    <th className="px-4 py-3">Stok</th>
+                    <th className="px-4 py-3">Status</th>
+                    <th className="px-4 py-3">Lokasi</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-neutral-200 dark:divide-neutral-800">
+                  {stockAlerts.map((item) => (
+                    <tr key={item.sku} className="bg-white dark:bg-neutral-900">
+                      <td className="px-4 py-3 font-mono text-xs text-neutral-500 dark:text-neutral-400">{item.sku}</td>
+                      <td className="px-4 py-3 font-medium">{item.name}</td>
+                      <td className="px-4 py-3">{item.status === "Overstock" ? "> 500" : item.status === "Stok menipis" ? "< 50" : "120"}</td>
+                      <td className="px-4 py-3">
+                        <span
+                          className={classNames(
+                            "inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium",
+                            item.priority === "high" && "bg-rose-50 text-rose-600 dark:bg-rose-500/10 dark:text-rose-300",
+                            item.priority === "medium" && "bg-amber-50 text-amber-600 dark:bg-amber-500/10 dark:text-amber-300",
+                            item.priority === "low" && "bg-emerald-50 text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-300"
+                          )}
+                        >
+                          {item.status}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-neutral-500 dark:text-neutral-400">{item.location}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </article>
+
+          <article className="rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900 lg:col-span-2">
+            <h2 className="text-lg font-semibold">Manajemen Stok</h2>
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">Prioritas otomatis berdasarkan level stok & pergerakan</p>
+            <ul className="mt-4 space-y-3 text-sm">
+              {stockAlerts.map((item) => (
+                <li key={item.sku} className="rounded-xl border border-neutral-200 p-3 dark:border-neutral-800">
+                  <div className="flex items-center justify-between">
+                    <span className="font-semibold text-neutral-800 dark:text-neutral-100">{item.name}</span>
+                    <span className="text-xs font-medium text-neutral-500 dark:text-neutral-400">{item.location}</span>
+                  </div>
+                  <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">{item.status}</p>
+                  <span className={classNames("mt-2 inline-block text-xs font-semibold", toneStyles[item.priority === "high" ? "critical" : item.priority === "medium" ? "warning" : "positive"]) }>
+                    {item.priority === "high" ? "Butuh restock segera" : item.priority === "medium" ? "Periksa rotasi" : "Aman"}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </article>
+        </section>
+
+        <section className="grid gap-4 lg:grid-cols-5">
+          <article className="rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900 lg:col-span-3">
+            <div className="flex items-start justify-between">
+              <div>
+                <h2 className="text-lg font-semibold">Pencatatan Barang Masuk & Keluar</h2>
+                <p className="text-sm text-neutral-500 dark:text-neutral-400">Aktivitas terbaru terhubung ke dashboard utama</p>
+              </div>
+              <button className="rounded-full border border-neutral-200 px-3 py-1 text-xs font-medium text-neutral-600 hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800">
+                Lihat semua
+              </button>
+            </div>
+            <ul className="mt-4 space-y-3">
+              {inboundOutbound.map((item) => (
+                <li key={item.reference} className="flex items-start gap-3 rounded-xl border border-neutral-200 p-3 dark:border-neutral-800">
+                  <span
+                    className={classNames(
+                      "mt-0.5 inline-flex h-8 w-8 items-center justify-center rounded-full text-sm font-semibold",
+                      item.type === "Inbound"
+                        ? "bg-emerald-500/10 text-emerald-500"
+                        : "bg-sky-500/10 text-sky-500"
+                    )}
+                  >
+                    {item.type === "Inbound" ? "+" : "−"}
+                  </span>
+                  <div className="flex-1">
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm font-medium text-neutral-800 dark:text-neutral-100">
+                      <span>{item.reference}</span>
+                      <span className="text-xs text-neutral-400 dark:text-neutral-500">{item.time}</span>
+                      <span className="text-xs text-neutral-400 dark:text-neutral-500">oleh {item.by}</span>
+                    </div>
+                    <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">{item.notes}</p>
+                  </div>
+                  <span className="text-sm font-semibold text-neutral-700 dark:text-neutral-200">{item.qty}</span>
+                </li>
+              ))}
+            </ul>
+          </article>
+
+          <article className="rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900 lg:col-span-2">
+            <h2 className="text-lg font-semibold">Laporan</h2>
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">Jadwalkan otomatis & sinkron ke ekosistem AKAY</p>
+            <ul className="mt-4 space-y-3 text-sm">
+              {reports.map((report) => (
+                <li key={report.title} className="rounded-xl border border-neutral-200 p-3 dark:border-neutral-800">
+                  <div className="flex items-center justify-between">
+                    <span className="font-semibold text-neutral-800 dark:text-neutral-100">{report.title}</span>
+                    <span className="text-xs text-neutral-400 dark:text-neutral-500">{report.period}</span>
+                  </div>
+                  <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">Status: {report.status}</p>
+                </li>
+              ))}
+            </ul>
+          </article>
+        </section>
+
+        <section className="grid gap-4 lg:grid-cols-5">
+          <article className="rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900 lg:col-span-3">
+            <h2 className="text-lg font-semibold">Pelacakan Lokasi Persediaan</h2>
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">Status kapasitas setiap area gudang</p>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              {locationMap.map((location) => {
+                const percent = Math.round((location.filled / location.capacity) * 100);
+                return (
+                  <div key={location.zone} className="rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <h3 className="text-sm font-semibold text-neutral-800 dark:text-neutral-100">{location.zone}</h3>
+                        <p className="text-xs text-neutral-500 dark:text-neutral-400">{location.racks}</p>
+                      </div>
+                      <span className="text-sm font-semibold text-neutral-700 dark:text-neutral-200">{percent}%</span>
+                    </div>
+                    <div className="mt-3 h-2 rounded-full bg-neutral-200 dark:bg-neutral-800">
+                      <div
+                        className="h-full rounded-full bg-emerald-500 dark:bg-emerald-400"
+                        style={{ width: `${Math.min(percent, 100)}%` }}
+                      />
+                    </div>
+                    <p className="mt-2 text-xs text-neutral-500 dark:text-neutral-400">
+                      {location.filled} dari {location.capacity} rak terisi
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+          </article>
+
+          <article className="rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900 lg:col-span-2">
+            <h2 className="text-lg font-semibold">Fitur Notifikasi</h2>
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">Sinkron dengan alert dashboard penjualan</p>
+            <ul className="mt-4 space-y-3 text-sm">
+              {notifications.map((notif) => (
+                <li key={notif.message} className="rounded-xl border border-neutral-200 p-3 dark:border-neutral-800">
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium text-neutral-800 dark:text-neutral-100">{notif.message}</span>
+                    <span className="text-xs text-neutral-400 dark:text-neutral-500">{notif.time}</span>
+                  </div>
+                  <span className={classNames("mt-2 inline-block text-xs font-semibold", toneStyles[notif.tone])}>
+                    {notif.tone === "critical"
+                      ? "Tindakan segera"
+                      : notif.tone === "success"
+                      ? "Selesai"
+                      : "Pengingat"}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </article>
+        </section>
+
+        <section className="grid gap-4 lg:grid-cols-5">
+          <article className="rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900 lg:col-span-3">
+            <h2 className="text-lg font-semibold">Manajemen Pengguna</h2>
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">Hak akses terintegrasi dengan login utama</p>
+            <div className="mt-4 overflow-hidden rounded-xl border border-neutral-200 dark:border-neutral-800">
+              <table className="min-w-full divide-y divide-neutral-200 text-sm dark:divide-neutral-800">
+                <thead className="bg-neutral-100 text-left text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:bg-neutral-800/60 dark:text-neutral-300">
+                  <tr>
+                    <th className="px-4 py-3">Nama</th>
+                    <th className="px-4 py-3">Peran</th>
+                    <th className="px-4 py-3">Status</th>
+                    <th className="px-4 py-3">Shift</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-neutral-200 dark:divide-neutral-800">
+                  {users.map((user) => (
+                    <tr key={user.name} className="bg-white dark:bg-neutral-900">
+                      <td className="px-4 py-3 font-medium">{user.name}</td>
+                      <td className="px-4 py-3 text-neutral-500 dark:text-neutral-400">{user.role}</td>
+                      <td className="px-4 py-3">
+                        <span
+                          className={classNames(
+                            "inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-semibold",
+                            user.status === "Aktif"
+                              ? "bg-emerald-500/10 text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-300"
+                              : "bg-neutral-200 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400"
+                          )}
+                        >
+                          {user.status}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-neutral-500 dark:text-neutral-400">{user.shift}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </article>
+
+          <article className="rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900 lg:col-span-2">
+            <h2 className="text-lg font-semibold">Stock Opname</h2>
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">Rencana opname lintas area gudang</p>
+            <ul className="mt-4 space-y-3 text-sm">
+              {opnamePlans.map((plan) => (
+                <li key={plan.area} className="rounded-xl border border-neutral-200 p-3 dark:border-neutral-800">
+                  <div className="flex items-center justify-between">
+                    <span className="font-semibold text-neutral-800 dark:text-neutral-100">{plan.area}</span>
+                    <span className="text-xs text-neutral-400 dark:text-neutral-500">{plan.schedule}</span>
+                  </div>
+                  <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">PJ: {plan.supervisor}</p>
+                  <span className="mt-2 inline-block text-xs font-semibold text-neutral-500 dark:text-neutral-400">{plan.status}</span>
+                </li>
+              ))}
+            </ul>
+          </article>
+        </section>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- aggregate advertising spend by channel based on the filtered dataset
- add a new bar chart to visualize ad spend per channel alongside existing spending charts

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68df35549be083209f24d42dcdcd0668